### PR TITLE
Generate accessor functions and Ruby bindings

### DIFF
--- a/magnus-macros/src/lib.rs
+++ b/magnus-macros/src/lib.rs
@@ -311,7 +311,7 @@ pub fn init(attrs: TokenStream, item: TokenStream) -> TokenStream {
 ///     Ok(())
 /// }
 /// ```
-/// 
+///
 /// See [`examples/inheritance.rs`] for the complete example.
 ///
 /// [`examples/inheritance.rs`]: https://github.com/matsadler/magnus/blob/main/examples/inheritance.rs


### PR DESCRIPTION
Magnus requires that users implement Rust functions for each field that Ruby should access, and then register that function with the Ruby class. That can end up generating as many as 10 lines of code per field, and when your application has a thousand fields across a hundred structs that imposes a significant burden both when reading and updating the code. This PR is an experiment to see to what degree that code can be auto-generated by macros.


Future improvements:
- [ ] Turn the `define` macros into a procedural macro so the magnus `init` function can be 99% removed
- [ ] Consider how (or if) this can support other use cases, like allowing Ruby to mutate a Rust struct, and how that should inform the API design
- [ ] Consider if struct definitions can be passed a single `class` attribute and have everything determined automatically from the data types contained in the struct
- [ ] Performance improvement: memoize Ruby methods so the value is retained for multiple calls
- [ ] [Auto-implement `magnus::IntoValueFromNative` in `magnus::wrap`](https://github.com/matsadler/magnus/issues/66#issuecomment-1464836712)
- [ ] [Improve Ruby time serialization so `to_s` isn't needed for Ruby method arguments](https://github.com/OneSignal/serde-magnus/issues/20)
- [ ] Generate Rails-like `inspect` and `to_h`

<details><summary><strong>Usage example</strong></summary>

```rs
// File: dataload/example.rs

#[cfg_attr(feature = "ruby", magnus::wrap(class = "Rust::Dataload::Example", free_immediately, size, accessors, bindings))]
pub struct Example {
    pub id: i64,
    pub start: DateTime<Utc>,
    pub end: DateTime<Utc>,
    pub table_names: Vec<String>,
    pub error: String,
}
#[cfg(feature = "ruby")]
unsafe impl magnus::IntoValueFromNative for Example {}

#[derive(Deserialize)]
pub struct Args {
    pub database_id: i64,
    pub start: DateTime<Utc>,
    pub end: DateTime<Utc>,
}

pub async fn call(Args { database_id, start, end }: Args) -> anyhow::Result<Vec<Example>> {
    let table_names = vec!["a".into(), "b".into()];
    Ok(vec![Example { id: database_id, start, end, error: "oh no".into(), table_names }])
}
```

```rs
// File: ruby.rs

use crate::*;
use magnus::*;

#[magnus::init]
fn init(ruby: &Ruby) -> Result<(), Error> {
    let rust = ruby.define_module("Rust")?;

    let dataload = rust.define_module("Dataload")?;
    define!(dataload, example);
    dataload::example::Example::bindings(ruby)?;

    Ok(())
}

/*

When defining a function:
- Rust functions must exist in a namespace like `query_explain::fingerprint::call` to map to `Rust::QueryExplain.fingerprint` in Ruby
- Functions must be async and return `anyhow::Result`
- Multiple arguments are treated like Ruby keyword arguments, wrapped in a struct implementing `serde::Deserialize`
- Complex return types use `magnus::wrap` and call their generated `bindings` function in this file
- Custom structs returned inside a Vec must implement `magnus::IntoValueFromNative`

*/

#[macro_export]
macro_rules! define {
    // Defines a Ruby method that returns typed Ruby objects
    ($module: ident, $method: ident) => {
        define!($module, $method, |r| r)
    };
    ($module: ident, $method: ident, $map: expr) => {
        let function = function!(
            |ruby: &Ruby, args: Value| {
                let result = runtime().block_on($module::$method::call(serde_magnus::deserialize(args)?));
                result.map($map).map_err(|e| Error::new(ruby.exception_standard_error(), e.to_string()))
            },
            1
        );
        $module.define_singleton_method(stringify!($method), function)?;
    };
}

// Defines a Ruby method that returns JSON as simple Ruby objects (Array, Hash, etc)
#[macro_export]
macro_rules! define_json {
    ($module: ident, $method: ident) => {
        define!($module, $method, |r| -> magnus::Value { serde_magnus::serialize(&r).unwrap() })
    };
}
